### PR TITLE
This patch fixes upstart_ensure command

### DIFF
--- a/src/cuisine.py
+++ b/src/cuisine.py
@@ -613,7 +613,7 @@ def ssh_authorize(user, key):
 def upstart_ensure(name):
     """Ensures that the given upstart service is running, restarting
     it if necessary"""
-    if sudo("service %s status" % name).find("is running") >= 0:
+    if sudo("service %s status" % name).find("running") >= 0:
         sudo("service %s restart" % name)
     else:
         sudo("service %s start" % name)


### PR DESCRIPTION
This patch fixes upstart_ensure command which is broken, because `service ... status` command returns `... start/running...` in some cases.
